### PR TITLE
fixes Issue #13 squelching haxe 3.2.0 errors

### DIFF
--- a/src/main/sys/db/Postgres.hx
+++ b/src/main/sys/db/Postgres.hx
@@ -336,7 +336,7 @@ class PostgresResultSet implements ResultSet {
 	public var length(get, null)  : Int;
 	public var nfields(get, null) : Int;
 
-	function get_length(){
+	function get_length():Int{
 	    if (set_length == null){
             cached_rows   = [for(row in data_iterator) row];
             set_length    = cached_rows.length + row_count;


### PR DESCRIPTION
i've created a docker image with haxe 3.2.0 and postgres to run tests

```
docker pull theremix/postgrehx:issue_13
```

the image has https://github.com/jdonaldson/postgrehx/tree/master checked out at `/app/postgrehx`  
and has this pull request commit https://github.com/theRemix/postgrehx/commit/e3df439effade74933cd67eebaa82ecbec2457be checked out to `/app/theremix`  

here's how to run the failing test (without this pull request)

```
docker run -it --rm -w /app/postgrehx theremix/postgrehx:issue_13 haxe build.hxml
```

output is:

```
./src/main/sys/db/Postgres.hx:339: lines 339-346 : Field get_length has different type than in sys.db.ResultSet
./src/main/sys/db/Postgres.hx:339: lines 339-346 : Void -> Null<Int> should be Void -> Int
./src/main/sys/db/Postgres.hx:339: lines 339-346 : Null<Int> should be Int
```

here is how  to run the test on my branch

```
docker run -it -d -w /app/theremix --name testing_postgrehx theremix/postgrehx:issue_13
docker exec testing_postgrehx service postgresql start
docker exec testing_postgrehx haxe build.hxml
```

output:

```
----------------------------------------PHP----------------------------------------
Class: sys.db.TestPostgres .........
Class: sys.db.TestSpodPostgres .

OK 10 tests, 0 failed, 10 success
----------------------------------------NEKO---------------------------------------
Class: sys.db.TestPostgres .........
Class: sys.db.TestSpodPostgres .

OK 10 tests, 0 failed, 10 success
```
